### PR TITLE
Fix latest release link

### DIFF
--- a/download.html
+++ b/download.html
@@ -205,7 +205,7 @@
 
     <footer class="container">
         <div>
-            <a href="https://github.com/CRLauncher/CRLauncher/releases/latest" class="file-url" data-file-type="">View
+            <a href="https://github.com/CRLauncher/CRLauncher/releases/latest">View
                 latest release on GitHub</a>
         </div>
     </footer>


### PR DESCRIPTION
The latest release link also had the "file-url" class so the script was trying to set a file download url on this too, but it didn't have any file type specified, which resulted in "undefined" at the end.